### PR TITLE
Pushing the static front end app to divshot.

### DIFF
--- a/divshot.json
+++ b/divshot.json
@@ -1,0 +1,6 @@
+{
+  "name": "sbirez",
+  "root": "./app",
+  "clean_urls": true,
+  "routes": { "**": "templates/index.html" }
+}


### PR DESCRIPTION
Application now exists at sbirez.colliderproject.org,
and is hosted at divshot. This is purely for feedback
purposes, contains only demo data, and does not save
any user data.

Fixes 18f/afsmallbiz#100
