### PR TITLE
Adding the username and id to the jwt token.

### DIFF
--- a/app/framework/factory.py
+++ b/app/framework/factory.py
@@ -18,7 +18,7 @@ from raven.contrib.flask import Sentry
 
 from .extensions import *
 from .middleware import HTTPMethodOverrideMiddleware
-from .security import authenticate, load_user, make_payload
+from .security import authenticate, load_user, make_payload, encode_payload, make_response
 from ..models.users import User, Role
 
 _log = logging.getLogger(__name__)
@@ -66,6 +66,8 @@ def create_app(package_name, package_path, settings_override=None,
     jwt.authentication_handler(authenticate)
     jwt.payload_handler(make_payload)
     jwt.user_handler(load_user)
+    jwt.encode_handler(encode_payload)
+    jwt.response_handler(make_response)
 
     # Sentry - only for production 
     if not app.debug and not app.testing and 'SENTRY_DSN' in app.config:

--- a/app/framework/security.py
+++ b/app/framework/security.py
@@ -11,8 +11,8 @@
 """
 import logging
 
-from flask import current_app
-from flask.ext.jwt import JWTError
+from flask import current_app, jsonify
+from flask.ext.jwt import JWTError, _get_serializer, verify_jwt
 from flask.ext.security.utils import verify_and_update_password
 from werkzeug.local import LocalProxy
 
@@ -43,15 +43,15 @@ def make_payload(user):
     """Returns a dictionary to be encoded based on the user."""
     return {
         "user_id": user.id,
-        "secret": user.secret
+        "secret": user.secret,
+        "username": user.name
     }
 
-# TODO - Delete this content after migration to cookiecutter-webapp is complete
-# def encode_payload(payload):
-#   return jsonify({'token': _get_serializer().dumps(payload).decode('utf-8'), 'username': payload['username'], 'id': payload['id']})
-#
-# def make_response(payload):
-#   return payload
-#
-# def auth_func(**kw):
-#   return True
+def encode_payload(payload):
+    return jsonify({'token': _get_serializer().dumps(payload).decode('utf-8'), 'username': payload['username'], 'id': payload['user_id']})
+
+def make_response(payload):
+    return payload
+
+def auth_func(**kw):
+    return True


### PR DESCRIPTION
It is helpful to have the user id included in the token to give the angular app a way to identify the user directly. The username is more of a convenience thing, it is included in the header. This way we don't need to immediately request a user object after logging in.