### PR TITLE
Implementing JWT Refresh Tokens.

### DIFF
--- a/afbirez/settings/base.py
+++ b/afbirez/settings/base.py
@@ -60,6 +60,7 @@ REST_SESSION_LOGIN = False
 JWT_AUTH = {
     'JWT_RESPONSE_PAYLOAD_HANDLER':'sbirez.utils.jwt_response_payload_handler',
     'JWT_EXPIRATION_DELTA': datetime.timedelta(seconds=3000),
+    'JWT_ALLOW_REFRESH': True,
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 }
 

--- a/afbirez/urls.py
+++ b/afbirez/urls.py
@@ -34,6 +34,7 @@ urlpatterns = patterns('',
 
     # jwt authentication endpoint
     url(r'^auth/', 'rest_framework_jwt.views.obtain_jwt_token'),
+    url(r'^auth-refresh/', 'rest_framework_jwt.views.refresh_jwt_token'),
 
     # angular app endpoint
     url(r'^$', 'sbirez.views.home', name='home'),

--- a/sbirez/static/js/services/tokensvc.js
+++ b/sbirez/static/js/services/tokensvc.js
@@ -1,11 +1,79 @@
 'use strict';
 
-angular.module('sbirezApp').factory('TokenInterceptor', function ($q, $window, $location, AuthenticationService) {
+angular.module('sbirezApp').factory('TokenInterceptor', function ($q, $window, $location, $injector, AuthenticationService) {
+
+  var EXPIRATION_DELTA = 1800000 // 30 minutes, in milliseconds
+  var expiration = null;
+  var urlBase64Decode = function(str) {
+    var output = str.replace(/-/g, '+').replace(/_/g, '/');
+    switch (output.length % 4) {
+      case 0: { break; }
+      case 2: { output += '=='; break; }
+      case 3: { output += '='; break; }
+      default: {
+        throw 'Illegal base64url string!';
+      }
+    }
+    return decodeURIComponent(escape(window.atob(output))); //polyfill https://github.com/davidchambers/Base64.js
+  }
+  
+  var decodeToken = function(token) {
+    var parts = token.split('.');
+    if (parts.length !== 3) {
+      throw new Error('JWT must have 3 parts');
+    }
+    var decoded = urlBase64Decode(parts[1]);
+    if (!decoded) {
+      throw new Error('Cannot decode the token');
+    }
+    return JSON.parse(decoded);
+  }
+
+  var getTokenExpirationDate = function(token) {
+    var decoded;
+    decoded = decodeToken(token);
+    if(!decoded.exp) {
+      return null;
+    }
+    var d = new Date(0); // The 0 here is the key, which sets the date to the epoch
+    d.setUTCSeconds(decoded.exp);
+    return d;
+  };
+
+  var isTokenExpired = function(token) {
+    var d = getTokenExpirationDate(token);
+    if (!d) {
+      return false;
+    }
+    // Token expired?
+    return !(d.valueOf() > new Date().valueOf());
+  };
+
   return {
     request: function (config) {
       config.headers = config.headers || {};
-      if ($window.sessionStorage.token) {
+      // only need the auth header if we are talking to our api
+      if ($window.sessionStorage.token && config.url.indexOf('api/') >= 0) {
         config.headers.Authorization = 'JWT ' + $window.sessionStorage.token;
+        if (expiration === null) {
+          expiration = getTokenExpirationDate($window.sessionStorage.token);
+        }
+        var now = new Date();
+        // if we are 'near enough' to the expiration, let's try and refresh the token
+        // it would be nice to handle expired tokens in a fault tolerant manner, but 
+        //  that'll require refactoring the auth code.
+        // ref: http://www.webdeveasy.com/interceptors-in-angularjs-and-useful-examples/
+        if (expiration - now < EXPIRATION_DELTA) {
+          // need to use the injector to avoid a circular dependency loop.
+          var UserService = $injector.get('UserService');
+          UserService.refreshToken().then(function(data) {
+            $window.sessionStorage.token = data.data.token;
+            expiration = getTokenExpirationDate($window.sessionStorage.token);
+          }, function(error) {
+            // don't immediately log the user out - could have been a server hiccup or something.
+            console.log('Failed to refresh the token.');
+          });
+        }
       }
       return config;
     },

--- a/sbirez/static/js/services/usersvc.js
+++ b/sbirez/static/js/services/usersvc.js
@@ -15,6 +15,10 @@ angular.module('sbirezApp').factory('UserService', function($http, $window, $roo
         $location.path('/');      
     },
 
+    refreshToken: function() {
+      return $http.post('auth-refresh/', {token: $window.sessionStorage.token});
+    },
+
     resetPassword: function(email) {
       return $http.post('rest-auth/password/reset/', {'email': email});
     },

--- a/sbirez/static/views/partials/activity.html
+++ b/sbirez/static/views/partials/activity.html
@@ -1,11 +1,11 @@
 <div class="row">
   <ul class="nav nav-pills nav-stacked sidebar col-md-2">
     <li><a ui-sref="app.activity.search">Search</a></li>
-    <li><a ui-sref="app.activity.proposals.list">Proposals</a></li>
-    <li><a ui-sref="app.activity.documents.list">Documents</a></li>
-    <li><a ui-sref="app.activity.savedOpps">Saved Opportunities</a></li>
-    <li><a ui-sref="app.activity.savedSearches">Saved Searches</a></li>
-    <li><a id="mainContent" ui-sref="app.activity.history">History</a></li>
+<!--    <li><a ui-sref="app.activity.proposals.list">Proposals</a></li> -->
+<!--    <li><a ui-sref="app.activity.documents.list">Documents</a></li> -->
+    <li><a id="mainContent" ui-sref="app.activity.savedOpps">Saved Opportunities</a></li>
+<!--    <li><a ui-sref="app.activity.savedSearches">Saved Searches</a></li> -->
+<!--    <li><a id="mainContent" ui-sref="app.activity.history">History</a></li> -->
   </ul>
   <div class="col-md-10" ui-view="activityContent">Activity SubView</div>
 </div>

--- a/sbirez/static/views/partials/savedOpps.html
+++ b/sbirez/static/views/partials/savedOpps.html
@@ -1,4 +1,3 @@
-<div ng-controller="SavedOppsCtrl">
 <p class="header-text">Saved Opportunities</p>
 <div ng-show="data.results && data.results.count === 0">
   <p>No Saved Opportunities Found</p>
@@ -10,5 +9,4 @@
     <button class="btn btn-default btn-sm" ng-click="removeOpportunity(topic.id)" title="Remove {{topic.topic_number}}" type="button">Remove Topic</button>
     <hr />
   </div>
-</div>
 </div>

--- a/tests/client/spec/services/usersvc.js
+++ b/tests/client/spec/services/usersvc.js
@@ -1,0 +1,76 @@
+'use strict';
+
+describe('Service: UserService', function () {
+
+  // load the controller's module
+  beforeEach(module('sbirezApp'));
+
+  var $window,
+    UserService,
+    $httpBackend,
+    AuthenticationService;
+
+  // Initialize the controller and a mock scope
+  beforeEach(inject(function (_$httpBackend_, _UserService_, _$window_, _AuthenticationService_) {
+    $httpBackend = _$httpBackend_;
+    $window = _$window_;
+    AuthenticationService = _AuthenticationService_;
+    $httpBackend.whenGET('static/views/partials/main.html').respond({});
+    $httpBackend.whenGET('static/views/partials/search.html').respond({});
+    UserService = _UserService_;
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+// logIn
+  it('should post to the backend with the expected user name and password', function() {
+    UserService.logIn('user', 'password');
+    $httpBackend.expect('POST', 'auth/', {email: 'user', password: 'password'}).respond(200);
+    $httpBackend.flush();
+  });
+
+// logOut
+  it('should clear session storage, set to unauthenticated, and redirect to root', function() {
+    $window.sessionStorage.token = 'abc';
+    $window.sessionStorage.username = 'Test';
+    $window.sessionStorage.userid = 1;
+    UserService.logOut('user', 'password');
+    expect($window.sessionStorage.token).toBe('');
+    expect($window.sessionStorage.username).toBe('null');
+    expect($window.sessionStorage.userid).toBe('null');
+    expect(AuthenticationService.getAuthenticated()).toBe(false);
+
+    $httpBackend.flush();
+  });
+
+// refreshToken
+  it('should post to the backend with the existing token', function() {
+    $window.sessionStorage.token = 'abc';
+    UserService.refreshToken();
+    $httpBackend.expect('POST', 'auth-refresh/', {token: 'abc'}).respond(200);
+    $httpBackend.flush();
+  });
+
+// resetPassword
+  it ('should post to the password reset endpoint', function() {
+    UserService.resetPassword('a@b.com');
+    $httpBackend.expect('POST', 'rest-auth/password/reset/', {'email': 'a@b.com'}).respond(200);
+    $httpBackend.flush();
+  });
+
+// createUser
+  it ('should post to the create user endpoint with correctly formatted parameters', function() {
+    $window.sessionStorage.token = '';
+    UserService.createUser('test', 'a@b.com', 'abc');
+    $httpBackend.expect('POST', 'api/v1/users/', 
+      {'name': 'test',
+       'email': 'a@b.com',
+       'password': 'abc',
+       'groups': [],
+       'is_staff': false }).respond(200);
+    $httpBackend.flush();
+  });
+});


### PR DESCRIPTION
Refresh tokens allow an active user to string along there session longer than the current session window. Essentially, if the application detects that less than a half hour remains on the current session, it will request an updated token from the server, effectively re-authenticating without the user needing to do anything. The underlying django app will allow this stringing along to happen for at most one week. The session, refresh delta, and the refresh token lifetime are all configurable.