### PR TITLE
Replaced the EmailUser with a SbirezUser and improving the user tests.

### DIFF
--- a/afbirez/settings/base.py
+++ b/afbirez/settings/base.py
@@ -69,7 +69,7 @@ ROOT_URLCONF = 'afbirez.urls'
 
 WSGI_APPLICATION = 'afbirez.wsgi.application'
 
-AUTH_USER_MODEL = 'custom_user.EmailUser'
+AUTH_USER_MODEL = 'sbirez.SbirezUser'
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/

--- a/sbirez/api.py
+++ b/sbirez/api.py
@@ -8,7 +8,8 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from sbirez.serializers import UserSerializer, GroupSerializer, TopicSerializer
 import marshmallow as mm
-
+from rest_framework.permissions import AllowAny
+from .permissions import IsStaffOrTargetUser
 
 class UserViewSet(viewsets.ModelViewSet):
     """
@@ -16,6 +17,11 @@ class UserViewSet(viewsets.ModelViewSet):
     """
     queryset = get_user_model().objects.all()
     serializer_class = UserSerializer
+
+    def get_permissions(self):
+        # allow non-authenticated user to create via POST
+        return (AllowAny() if self.request.method == 'POST'
+                else IsStaffOrTargetUser()),
 
 
 class GroupViewSet(viewsets.ModelViewSet):

--- a/sbirez/fixtures/topictest.yaml
+++ b/sbirez/fixtures/topictest.yaml
@@ -14439,6 +14439,7 @@
 - fields:
     date_joined: 2015-03-07 00:57:24.820367+00:00
     email: r2d2@naboo.gov
+    name: r2d2
     groups: []
     is_active: true
     is_staff: false
@@ -14446,7 +14447,7 @@
     last_login: 2015-03-07 00:57:24.820336+00:00
     password: pbkdf2_sha256$15000$oflx16nPNOnI$4IJCuNpk/1K6PHAzoIl4A84sCfkwSuSXXX9SVYUCvBU=
     user_permissions: []
-  model: custom_user.emailuser
+  model: sbirez.sbirezuser
   pk: 2
 - fields: {agency: AirForce, description: "Since the launch of Sputnik I, the U.S.
       Air Force has been interested in monitoring Earth orbiting objects. With this

--- a/sbirez/migrations/0001_initial.py
+++ b/sbirez/migrations/0001_initial.py
@@ -2,14 +2,37 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-
+import django.utils.timezone
 
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('auth', '0001_initial'),
     ]
 
     operations = [
+        migrations.CreateModel(
+            name='SbirezUser',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(verbose_name='last login', default=django.utils.timezone.now)),
+                ('is_superuser', models.BooleanField(verbose_name='superuser status', help_text='Designates that this user has all permissions without explicitly assigning them.', default=False)),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('is_staff', models.BooleanField(verbose_name='staff status', help_text='Designates whether the user can log into this admin site.', default=False)),
+                ('is_active', models.BooleanField(verbose_name='active', help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', default=True)),
+                ('date_joined', models.DateTimeField(verbose_name='date joined', default=django.utils.timezone.now)),
+                ('name', models.TextField()),
+                ('groups', models.ManyToManyField(related_name='user_set', blank=True, related_query_name='user', help_text='The groups this user belongs to. A user will get all permissions granted to each of his/her group.', verbose_name='groups', to='auth.Group')),
+                ('user_permissions', models.ManyToManyField(related_name='user_set', blank=True, related_query_name='user', help_text='Specific permissions for this user.', verbose_name='user permissions', to='auth.Permission')),
+            ],
+            options={
+                'abstract': False,
+                'verbose_name': 'user',
+                'verbose_name_plural': 'users',
+            },
+            bases=(models.Model,),
+        ),
         migrations.CreateModel(
             name='Area',
             fields=[

--- a/sbirez/models.py
+++ b/sbirez/models.py
@@ -3,6 +3,10 @@ from django.utils import timezone
 from djorm_pgfulltext.fields import VectorField
 from djorm_pgfulltext.models import SearchManager
 from django.conf import settings
+from custom_user.models import AbstractEmailUser
+
+class SbirezUser(AbstractEmailUser):
+    name = models.TextField()
 
 class Area(models.Model):
     area = models.TextField(unique=True)

--- a/sbirez/permissions.py
+++ b/sbirez/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework import permissions
+ 
+ 
+class IsStaffOrTargetUser(permissions.BasePermission):
+    def has_permission(self, request, view):
+        # allow user to list all users if logged in user is staff
+        return view.action != 'list' or request.user.is_staff
+        #return True
+ 
+    def has_object_permission(self, request, view, obj):
+        # allow logged in user to view own details, allows staff to view all records
+        return request.user.is_staff or obj == request.user

--- a/sbirez/serializers.py
+++ b/sbirez/serializers.py
@@ -3,15 +3,15 @@ from sbirez.models import Topic, Reference, Phase, Keyword, Area
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
 
     saved_topics = serializers.HyperlinkedRelatedField(many=True,
-                                                       view_name='topic-detail',
+                                                       view_name='topics-detail',
                                                        read_only=True)
 
     class Meta:
         model = get_user_model()
-        fields = ('password', 'url', 'email', 'groups', 'saved_topics',)
+        fields = ('name', 'password', 'url', 'email', 'groups', 'saved_topics',)
         write_only_fields = ('password',)
 
     def create(self, validated_data):
@@ -56,7 +56,7 @@ class ReferenceSerializer(serializers.ModelSerializer):
         fields = ('reference', )
 
 
-class TopicSerializer(serializers.ModelSerializer):
+class TopicSerializer(serializers.HyperlinkedModelSerializer):
     references = ReferenceSerializer(many=True)
     phases = PhaseSerializer(many=True)
     keywords = KeywordSerializer(many=True)


### PR DESCRIPTION
Replacing the auth user model needs to be done in the initial migration.
* Edited the initial migration to create the SbirezUser.
* Added IsStaffOrTargetedUser custom permission to apply to the user endpoint.
* Added a name for the default test user (r2d2).
* Corrected the user/saved-topics linkage in the serializer
* Added 10 new tests to exercise the authed/non-authed user.