### PR TITLE
Fix styling on forgot password panel.

### DIFF
--- a/sbirez/static/views/partials/login.html
+++ b/sbirez/static/views/partials/login.html
@@ -78,25 +78,21 @@
   <div ng-show="getMode()==='reset'" class="login-form">
     <p class="dialog-header-text">Reset Your Password</p>
     <form id="reset-form" role="form">
-      <div class="row">
+      <div>
         <p>We will send a password reset link to the email address below:</p>
       </div>
-      <div class="row">
-        <div class="form-group col-md-12">
-          <label for="inputUsername" class="sr-only">Email:</label>
-          <input type="text" class="form-control" id="inputUsername" placeholder="Email" ng-model="signup.email">
-        </div>
+      <div class="form-group">
+        <label for="inputUsername" class="sr-only">Email:</label>
+        <input type="text" class="form-control" id="inputUsername" placeholder="Email" ng-model="signup.email">
       </div>
       <div ng-show="errorMsg" class="text-danger"><p>{{errorMsg}}</p></div>
       <div ng-show="successMsg" class="text-info"><p>{{successMsg}}</p></div>
-      <div class="row">
-        <div ng-hide="successMsg" class="form-group col-md-12">
-          <button type="submit" class="btn btn-default" ng-click="resetPassword(signup.email)">Reset</button>
-          <button type="submit" class="btn btn-default" ng-click="cancel()">Cancel</button>
-        </div>
-        <div ng-show="successMsg" class="form-group col-md-12">
-          <button type="submit" class="btn btn-default" ng-click="cancel()">OK</button>
-        </div>
+      <div ng-hide="successMsg" class="form-group">
+        <button type="submit" class="btn btn-default" ng-click="resetPassword(signup.email)">Reset</button>
+        <button type="submit" class="btn btn-default" ng-click="cancel()">Cancel</button>
+      </div>
+      <div ng-show="successMsg" class="form-group">
+        <button type="submit" class="btn btn-default" ng-click="cancel()">OK</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
The forgot password dialog used to look like this

![screen shot 2015-04-07 at 11 04 07 am](https://cloud.githubusercontent.com/assets/1633460/7026690/4387cc5e-dd19-11e4-9d6e-3216b787bd41.png)

But probably it should look like this

![screen shot 2015-04-07 at 11 03 53 am](https://cloud.githubusercontent.com/assets/1633460/7026695/487c449c-dd19-11e4-9d2c-f9bffd75a1c0.png)

This patch also removes some probably-superfluous divs. If those are there for a reason, I'll revise.