### PR TITLE
File available from document or documentversion as /file/

### DIFF
--- a/afbirez/urls.py
+++ b/afbirez/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.views.generic import TemplateView
 
 from rest_framework import routers
-from sbirez import api
+from sbirez import api, models
 
 router = routers.DefaultRouter()
 router.register(r'users', api.UserViewSet)
@@ -43,6 +43,12 @@ urlpatterns = patterns('',
     url(r'^password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         TemplateView.as_view(template_name="password_reset_confirm.html"),
         name='password_reset_confirm'),
+
+    # permit downloads of uploaded files
+    url(r'^api/v1/documents/(?P<pk>[0-9]+)/file/$',
+        api.FileDownloadView.as_view(model=models.Document, file_field='file')),
+    url(r'^api/v1/documentversions/(?P<pk>[0-9]+)/file/$',
+        api.FileDownloadView.as_view(model=models.DocumentVersion, file_field='file')),
 
     # jwt authentication endpoint
     url(r'^auth/', 'rest_framework_jwt.views.obtain_jwt_token'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ddlgenerator==0.1.9
 Django==1.8
 django-assets==0.10
 django-custom-user==0.5
+django-downloadview==1.6
 django-rest-auth==0.3.4
 djangorestframework==3.1.1
 djangorestframework-hstore==1.2

--- a/sbirez/api.py
+++ b/sbirez/api.py
@@ -12,6 +12,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from sbirez.serializers import UserSerializer, GroupSerializer, TopicSerializer
+from django_downloadview import ObjectDownloadView
 
 from sbirez.serializers import FirmSerializer, ProposalSerializer, PartialProposalSerializer
 from sbirez.serializers import WorkflowSerializer, AddressSerializer, ElementSerializer
@@ -228,6 +229,12 @@ class DocumentViewSet(viewsets.ModelViewSet):
         # from before the new version was attached
         result = self.retrieve(request, pk=result.data['id'])
         return result
+
+
+class FileDownloadView(ObjectDownloadView):
+
+    def get(self, request, pk):
+        return super(FileDownloadView, self).get(request)
 
 
 class DocumentVersionViewSet(viewsets.ModelViewSet):

--- a/sbirez/api.py
+++ b/sbirez/api.py
@@ -198,7 +198,7 @@ class PersonViewSet(viewsets.ModelViewSet):
 class DocumentViewSet(viewsets.ModelViewSet):
     queryset = Document.objects.all()
     serializer_class = DocumentSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, HasObjectEditPermissions, )
 
     def get_queryset(self):
         queryset = Document.objects.all()
@@ -206,40 +206,44 @@ class DocumentViewSet(viewsets.ModelViewSet):
             queryset = Document.objects.filter(firm=self.request.user.firm)
         return queryset
 
-    def get_permissions(self):
-        return [IsAuthenticated(), HasObjectEditPermissions(),]
+    def create(self, request, *args, **kwargs):
+        data = dict(request.data.items())
+        data['firm'] = request.user.firm_id
 
-    def create(self, request):
-        result = super(DocumentViewSet, self).create(request)
+        # cut-and-pasted from rest_framework.mixins.CreateModelMixin, because I can't
+        # find a way to make it accept an edit to request.data
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        result = Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
         ver = DocumentVersion(file=request.data['file'],
                               document_id=result.data['id'])
         ver.save()
         return result
 
     def update(self, request, *posargs, **kwargs):
-        try:
-            file = request.data.pop('file', None)
-        except (KeyError, AttributeError):
-            file = None
+        # TODO: What if you try to update the `firm`?
+
         result = super(DocumentViewSet, self).update(request, *posargs, **kwargs)
-        if file:
-            ver = DocumentVersion(file=file[0], document_id = result.data['id'])
+        if 'file' in request.data:
+            ver = DocumentVersion(file=request.data['file'], document_id = result.data['id'])
             ver.save()
+
         # re-querying seems awful, but otherwise the result contains obsolete data
         # from before the new version was attached
         result = self.retrieve(request, pk=result.data['id'])
         return result
 
 
-class FileDownloadView(ObjectDownloadView):
+class FileDownloadView(ObjectDownloadView, generics.GenericAPIView):
 
-    def get(self, request, pk):
-        return super(FileDownloadView, self).get(request)
+    permission_classes = (IsStaffOrFirmRelatedUser, )
 
 
 class DocumentVersionViewSet(viewsets.ModelViewSet):
     queryset = DocumentVersion.objects.all()
     serializer_class = DocumentVersionSerializer
     permission_classes = (IsAuthenticated,)
-
 

--- a/sbirez/permissions.py
+++ b/sbirez/permissions.py
@@ -23,7 +23,9 @@ class IsStaffOrTargetUser(permissions.BasePermission):
 class IsStaffOrFirmRelatedUser(permissions.BasePermission):
     def has_permission(self, request, view):
         # allow user to list all firms if staff
-        return (request.user.is_authenticated() and view.action != 'list') or request.user.is_staff
+        return (request.user.is_authenticated()
+                and (not hasattr(view, 'action') or view.action != 'list')
+                ) or request.user.is_staff
 
     def has_object_permission(self, request, view, obj):
         # allow logged in user to view view/edit own firm
@@ -37,7 +39,7 @@ class HasObjectEditPermissions(permissions.BasePermission):
         # allow user to list proposals if staff
         return True
         # (request.user.is_authenticated() and view.action != 'list') or request.user.is_staff
- 
+
     def has_object_permission(self, request, view, object):
         # allow logged in user to view view/edit proposals from firm
         # if a user is authed and is associated with the firm

--- a/sbirez/serializers.py
+++ b/sbirez/serializers.py
@@ -335,6 +335,8 @@ class DocumentVersionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DocumentVersion
+        fields = ('id', 'document', 'note',
+                  'created_at', 'updated_at', 'hash', )
 
 
 class DocumentSerializer(serializers.ModelSerializer):
@@ -345,12 +347,10 @@ class DocumentSerializer(serializers.ModelSerializer):
     versions = serializers.PrimaryKeyRelatedField(
         many=True, read_only=True)
 
-    file = serializers.FileField()
-
     class Meta:
         model = Document
         fields = ('id', 'name', 'description', 'created_at',
                   'updated_at', 'firm', 'proposals',
-                  'versions', 'file',
+                  'versions',
                   )
 

--- a/sbirez/test_api.py
+++ b/sbirez/test_api.py
@@ -1018,6 +1018,16 @@ class DocumentTests(APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertIn('deathstarplans', response.data['file'])
 
+    def test_document_download(self):
+        response = _upload_death_star_plans(self)
+        response = self.client.get('/api/v1/documents/%d/' % response.data['id'])
+        document_number = response.data['id']
+        version_number = response.data['versions'][0]
+        response = self.client.get('/api/v1/documents/%d/file/' % document_number)
+        self.assertEqual(response.get_mime_type(), 'text/plain')
+        response = self.client.get('/api/v1/documentversions/%d/file/' % version_number)
+        self.assertEqual(response.get_mime_type(), 'text/plain')
+
     def test_patch_file(self):
         response = _upload_death_star_plans(self)
         doc_url = '/api/v1/documents/%d/' % response.data['id']


### PR DESCRIPTION
Ready for review (but not merge).  Should be able to get a streaming file object at

/api/v1/document/<pk>/file/

/api/v1/documentversion/<pk>/file/

The actual value contained in the 'file' field turns out not to be needed/relevant for this.