### PR TITLE
Creating a custom JSONWebTokenAuthentication class for query string tokens.

### DIFF
--- a/afbirez/settings/base.py
+++ b/afbirez/settings/base.py
@@ -51,7 +51,7 @@ REST_FRAMEWORK = {
     'PAGINATE_BY_PARAM': 'page_size',
     'MAX_PAGINATE_BY': 200,
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'sbirez.utils.JSONWebTokenAuthenticationFlex',
         'rest_framework.authentication.TokenAuthentication',
     ),
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-custom-user==0.5
 django-rest-auth==0.3.4
 djangorestframework==3.1.1
 djangorestframework-hstore==1.2
-djangorestframework-jwt==1.2.0
+djangorestframework-jwt==1.4.0
 djangorestframework-recursive==0.1.0
 dj-database-url==0.3.0
 djorm-ext-pgfulltext==0.9.3

--- a/sbirez/utils.py
+++ b/sbirez/utils.py
@@ -1,7 +1,47 @@
+import jwt
+from django.utils.encoding import smart_text
+from django.utils.translation import ugettext as _
+from rest_framework import exceptions
+from rest_framework.authentication import (BaseAuthentication,
+                                           get_authorization_header)
+from rest_framework_jwt import utils
+from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication 
+
 # Utility methods for the sbirez application
+class JSONWebTokenAuthenticationFlex(BaseJSONWebTokenAuthentication):
+
+    www_authenticate_realm = 'api'
+
+    def get_jwt_value(self, request):
+        auth = get_authorization_header(request).split()
+        auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
+
+        if not auth or smart_text(auth[0].lower()) != auth_header_prefix:
+            return request.QUERY_PARAMS.get('jwt')
+
+        if len(auth) == 1:
+            msg = _('Invalid Authorization header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid Authorization header. Credentials string '
+                    'should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth[1]
+
+    def authenticate_header(self, request):
+        """
+        Return a string to be used as the value of the `WWW-Authenticate`
+        header in a `401 Unauthenticated` response, or `None` if the
+        authentication scheme should return `403 Permission Denied` responses.
+        """
+        return 'JWT realm="{0}"'.format(self.www_authenticate_realm)
+
+
 
 # custom payload handler to add the user name and id to the jwt token.
-def jwt_response_payload_handler(token, user=None):
+def jwt_response_payload_handler(token, user=None, request=None):
     return {
         'token': token,
         'id': user.id,


### PR DESCRIPTION
File downloads that require a user to be authenticated need to have an alternate method of providing the JSON Web Token to the server. This commit:
* Updates djangorestframework-jwt to version 1.4.0, which added a BaseJSONWebTokenAuthentication class from which to inherit.
* Adds a JSONWebTokenAuthenticationFlex class which will look for a header then fall back to a `jwt` query string parameter before failing authentication.
* Updates the DEFAULT_AUTHENTICATION_CLASSES to use this new class instead of the default one.