### PR TITLE
Adding an atob polyfill for IE support.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "angular-order-object-by": "~1.1.0",
     "angular-marked": "~0.0.12",
     "jquery": "~2.1.4",
-    "jquery-ui": "~1.11.4"
+    "jquery-ui": "~1.11.4",
+    "base64": "0.3.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.3",

--- a/sbirez/assets.py
+++ b/sbirez/assets.py
@@ -13,6 +13,7 @@ bower_js = Bundle(
     "lib/angular-order-object-by/src/ng-order-object-by.js",
     "lib/marked/lib/marked.js",
     "lib/angular-marked/angular-marked.js",
+    "lib/base64/base64.min.js",
     filters="jsmin",
     output="js/bower.min.js"
 )


### PR DESCRIPTION
The way we process JWT tokens uses atob, which isn't available in all browsers. This adds support for it via the base64 shim.