### PR TITLE
Removing dependency on sass external tool.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ psycopg2==2.6
 waitress==0.8.9
 whitenoise==1.0.6
 xlrd==0.9.3
+pyscss==1.3.4
 -r requirements/dev.txt

--- a/sbirez/assets.py
+++ b/sbirez/assets.py
@@ -74,7 +74,7 @@ angular_js = Bundle(
 
 combined_sass = Bundle(
     "sass/main.scss",
-    filters="scss",
+    filters="pyscss",
     output="css/main.min.css"
 )
 


### PR DESCRIPTION
I've received intermittent failures from CF deploys based on if the css needs to be re-compiled. This replaces the dependency on the external gem with pyscss, which is installable via pip.