### PR TITLE
Correcting a bug with IE 11 on the proposal pages.

### DIFF
--- a/sbirez/static/sass/main.scss
+++ b/sbirez/static/sass/main.scss
@@ -143,6 +143,7 @@ summary.error-message{
     line-height: 18px;
     margin-bottom: 24px;
     margin-top: -8px;
+    display: block;
 }
 
 summary.error-message details{ margin-top: 8px; }


### PR DESCRIPTION
The error summary blocks on the proposal pages were not showing up properly in IE 11. This corrects it.