### PR TITLE
Adding django-sslify to force https on CloudFoundry.

### DIFF
--- a/afsbirez/settings/base.py
+++ b/afsbirez/settings/base.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = (
+    'sslify.middleware.SSLifyMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/afsbirez/settings/dev.py
+++ b/afsbirez/settings/dev.py
@@ -23,3 +23,5 @@ DJMAIL_REAL_BACKEND="django.core.mail.backends.console.EmailBackend"
 INSTALLED_APPS.append('django_extensions')
 
 REST_PROXY['API_KEY'] = 'DEMO_KEY'
+
+SSLIFY_DISABLE = True

--- a/afsbirez/settings/production.py
+++ b/afsbirez/settings/production.py
@@ -41,3 +41,5 @@ EMAIL_USE_SSL = True
 # store email credentials in `credentials.py` (outside version control)
 
 REST_PROXY['API_KEY'] = SAM_API_KEY
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ waitress==0.8.9
 whitenoise==1.0.6
 xlrd==0.9.3
 pyscss==1.3.4
+django-sslify==0.2.7
 -r requirements/dev.txt


### PR DESCRIPTION
This adds django-sslify to the requirements file and enables it for production mode.