### PR TITLE
Addresses url suggestions made by Andrew in #183

### DIFF
--- a/afsbirez/urls.py
+++ b/afsbirez/urls.py
@@ -60,9 +60,9 @@ urlpatterns = patterns('',
     url(r'^$', 'sbirez.views.home', name='home'),
     url(r'^search/', 'sbirez.views.home', name='home'),
     url(r'^topic/', 'sbirez.views.home', name='home'),
-    url(r'^app/', 'sbirez.views.home', name='home'),
-    url(r'^signin/', 'sbirez.views.home', name='home'),
-    url(r'^signup/', 'sbirez.views.home', name='home'),
+    url(r'^~/', 'sbirez.views.home', name='home'),
+    url(r'^signin', 'sbirez.views.home', name='home'),
+    url(r'^signup', 'sbirez.views.home', name='home'),
     url(r'^reset/', 'sbirez.views.home', name='home'),
 
     # proxy company info searches to SAM API

--- a/sbirez/static/js/app.js
+++ b/sbirez/static/js/app.js
@@ -69,7 +69,7 @@ angular.module('sbirezApp', [
         }
       })
       .state('app', {
-        url: '/app',
+        url: '/~',
         abstract: true,
         access: {requiredAuthentication: true},
         views: {
@@ -181,30 +181,20 @@ angular.module('sbirezApp', [
         },
         access: { requiredAuthentication: true }
       })
-      .state('app.account', {
-        url: '/account',
-        abstract: 'true',
-        views: {
-          'tabContent': {
-            templateUrl: 'static/views/partials/account.html',
-          }
-        },
-        access: { requiredAuthentication: true }
-      })
-      .state('app.account.user', {
+      .state('app.user', {
         url: '',
         views: {
-          'accountContent': {
+          'tabContent': {
             templateUrl: 'static/views/partials/accountUser.html',
             controller: 'AccountUserCtrl'
           }
         },
         access: { requiredAuthentication: true }
       })
-      .state('app.account.organization', {
-        url: '/organization',
+      .state('app.organization', {
+        url: '/company',
         views: {
-          'accountContent': {
+          'tabContent': {
             templateUrl: 'static/views/partials/accountOrganization.html',
             controller: 'AccountOrganizationCtrl'
           }

--- a/sbirez/static/js/controllers/main.js
+++ b/sbirez/static/js/controllers/main.js
@@ -14,7 +14,7 @@ angular.module('sbirezApp')
 
     if ($scope.isLoggedIn && $state.includes('home')) {
       console.log($state);
-      $location.path('/app/proposals');
+      $location.path('/~/proposals');
     } else if ($rootScope.preproduction) {
       DialogService.openIntroMessage();
     }

--- a/sbirez/static/js/directives/header.js
+++ b/sbirez/static/js/directives/header.js
@@ -20,11 +20,11 @@ angular.module('sbirezApp').directive('header', function() {
             $scope.menu = [{
               'class': 'my-topics',
               'title': 'My Proposals',
-              'link': '/app/proposals'
+              'link': '/~/proposals'
             }, {
               'class': 'my-company',
               'title': 'My Company',
-              'link': '/app/account/organization'
+              'link': '/~/company'
             }, {
               'class': 'sign-out',
               'title': 'Sign Out',

--- a/sbirez/static/views/partials/account.html
+++ b/sbirez/static/views/partials/account.html
@@ -1,1 +1,0 @@
-<div ui-view="accountContent"></div>

--- a/sbirez/static/views/partials/landing.html
+++ b/sbirez/static/views/partials/landing.html
@@ -1,9 +1,9 @@
 <main role="main">
   <div class="wrap">
     <h1>Tell us about your company now?</h1>
-    <p>Before you can submit a proposal on a solicitation, you&rsquo;ll need to tell us a little bit about your company. You can do that at any time by clicking <a ui-sref="app.account.organization">My Company</a> in the header.</p>
+    <p>Before you can submit a proposal on a solicitation, you&rsquo;ll need to tell us a little bit about your company. You can do that at any time by clicking <a ui-sref="app.organization">My Company</a> in the header.</p>
     <footer>
-      <a ui-sref="app.account.organization" class="button">Let&rsquo;s setup my company</a>
+      <a ui-sref="app.organization" class="button">Let&rsquo;s setup my company</a>
       <div>
         <a ui-sref="app.proposals.list" aria-describedby="first-proposal-reminder">I&rsquo;ll do this later</a>
         <p id="first-proposal-reminder">(We&rsquo;ll check for this information as you submit your first proposal.)</p>          

--- a/sbirez/static/views/partials/proposal.report.html
+++ b/sbirez/static/views/partials/proposal.report.html
@@ -33,7 +33,7 @@
         <button type="button" id="validate_state" ng-click="validate()">{{verifyButton}}</button>          
         <button ng-if="showSubmit" type="button" id="submit" ng-click="submit()">{{submitButton}}</button>
         <div ng-if="!showContinue" class="notice">
-          <p><strong>Note:</strong> You&rsquo;ll need to fill in <a ui-sref="app.account.organization">your company information</a> before you can submit a proposal.</p>
+          <p><strong>Note:</strong> You&rsquo;ll need to fill in <a ui-sref="app.organization">your company information</a> before you can submit a proposal.</p>
         </div>
       </section>
       <!--<aside>

--- a/tests/client/spec/controllers/document.js
+++ b/tests/client/spec/controllers/document.js
@@ -89,9 +89,5 @@ describe('Controller: DocumentCtrl', function () {
     $httpBackend.flush();
     $httpBackend.expectDELETE('api/v1/documents/1/').respond(200, '');
     scope.remove();
-    $httpBackend.expectGET('static/views/partials/appmain.html').respond(200, '');
-    $httpBackend.expectGET('static/views/partials/document.html').respond(200, '');
-    $httpBackend.expectGET('static/views/partials/documentList.html').respond(200, '');
-    $httpBackend.flush();
   });
 });

--- a/tests/client/spec/controllers/signin.js
+++ b/tests/client/spec/controllers/signin.js
@@ -63,27 +63,27 @@ describe('Controller: SignInCtrl', function () {
     var mockDeferred = $q.defer();
     spyOn(UserService, 'logIn').andReturn(mockDeferred.promise);
     spyOn(UserService, 'getUserDetails').andReturn(mockDeferred.promise);
-    scope.intention = {'target': '/app/proposals/5'};
+    scope.intention = {'target': '/~/proposals/5'};
     scope.email = data.data.username;
     scope.password = '123';
     scope.logIn();
     mockDeferred.resolve(data);
     scope.$root.$digest();
     expect(window.sessionStorage.token).toBe(data.data.token);
-    expect($location.path()).toBe('/app/proposals/5');
+    expect($location.path()).toBe('/~/proposals/5');
   });
 
   it ('should honor the target query string, if present, even if url encoded', function () {
     var mockDeferred = $q.defer();
     spyOn(UserService, 'logIn').andReturn(mockDeferred.promise);
     spyOn(UserService, 'getUserDetails').andReturn(mockDeferred.promise);
-    scope.intention = {'target': '%2Fapp%2Fproposals%2F5'};
+    scope.intention = {'target': '%2F~%2Fproposals%2F5'};
     scope.email = data.data.username;
     scope.password = '123';
     scope.logIn();
     mockDeferred.resolve(data);
     scope.$root.$digest();
     expect(window.sessionStorage.token).toBe(data.data.token);
-    expect($location.path()).toBe('/app/proposals/5');
+    expect($location.path()).toBe('/~/proposals/5');
   });
 });

--- a/tests/client/spec/controllers/signup.js
+++ b/tests/client/spec/controllers/signup.js
@@ -51,7 +51,7 @@ describe('Controller: SignUpCtrl', function () {
     spyOn(UserService, 'createUser').andReturn(mockDeferred.promise);
     spyOn(UserService, 'logIn').andReturn(mockDeferred.promise);
     spyOn(UserService, 'getUserDetails').andReturn(mockDeferred.promise);
-    scope.intention = {'target': '/app/proposals/5'};
+    scope.intention = {'target': '/~/proposals/5'};
     scope.email = data.data.username;
     scope.name = 'Test User';
     scope.password = 'Abc123!2';
@@ -59,7 +59,7 @@ describe('Controller: SignUpCtrl', function () {
     mockDeferred.resolve(data);
     scope.$root.$digest();
     expect(window.sessionStorage.token).toBe(data.data.token);
-    expect($location.path()).toBe('/app/proposals/5');
+    expect($location.path()).toBe('/~/proposals/5');
   });
 
   it ('should honor the target query string, if present, even if url encoded', function () {
@@ -67,7 +67,7 @@ describe('Controller: SignUpCtrl', function () {
     spyOn(UserService, 'createUser').andReturn(mockDeferred.promise);
     spyOn(UserService, 'logIn').andReturn(mockDeferred.promise);
     spyOn(UserService, 'getUserDetails').andReturn(mockDeferred.promise);
-    scope.intention = {'target': '%2Fapp%2Fproposals%2F5'};
+    scope.intention = {'target': '%2F~%2Fproposals%2F5'};
     scope.email = data.data.username;
     scope.name = 'Test User';
     scope.password = 'Abc123!2';
@@ -75,7 +75,7 @@ describe('Controller: SignUpCtrl', function () {
     mockDeferred.resolve(data);
     scope.$root.$digest();
     expect(window.sessionStorage.token).toBe(data.data.token);
-    expect($location.path()).toBe('/app/proposals/5');
+    expect($location.path()).toBe('/~/proposals/5');
   });
 
   it('should not redirect and it should return an error', function () {


### PR DESCRIPTION
* Fixes issue with signin and signup redirecting to the home page if you navigate to them directly.
* Renames app to ~, so authed urls are now localhost:8000/~/proposals
* Promotes account/organization to company, so the page is accessible via ~/company