### PR TITLE
Altering the percentage validation logic to accept larger values.

### DIFF
--- a/sbirez/models.py
+++ b/sbirez/models.py
@@ -187,7 +187,7 @@ class Element(models.Model):
         'zip': re.compile(
             '''^\d{5}(-\d{4})?$'''
             , re.IGNORECASE),
-        'percent': lambda x: 0 <= x <= 100,
+        'percent': lambda x: 0 <= x <= 1000,
         'integer': lambda x: isinstance(x, int),
     }
 

--- a/sbirez/static/js/services/validationsvc.js
+++ b/sbirez/static/js/services/validationsvc.js
@@ -294,8 +294,8 @@ angular.module('sbirezApp').factory('ValidationService', function() {
         response = 'Invalid percentage';
         value = data[element.name];
         if (isFinite(value)) {
-          value = parseInt(value);
-          if (value >= 0 && value <= 100) {
+          value = parseFloat(value);
+          if (value >= 0 && value <= 1000) {
             return true;
           }
         }

--- a/sbirez/test_api.py
+++ b/sbirez/test_api.py
@@ -1375,6 +1375,27 @@ class ProposalValidationTests(APITestCase):
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(response.data, {'non_field_errors': ['Not a valid percent']})
 
+    def test_element_type_percent_validation_greater_than_100_pass(self):
+        user = _fixture_user(self)
+        data = deepcopy(self.data)
+        data["data"] = json.loads(data["data"])
+        data["data"]["minstrels"]["0"]["skill"] = 122
+        data["data"] = json.dumps(data["data"])
+
+        response = self.client.post('/api/v1/proposals/', data)
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+    def test_element_type_percent_validation_greater_than_1000_fail(self):
+        user = _fixture_user(self)
+        data = deepcopy(self.data)
+        data["data"] = json.loads(data["data"])
+        data["data"]["minstrels"]["0"]["skill"] = 1001
+        data["data"] = json.dumps(data["data"])
+
+        response = self.client.post('/api/v1/proposals/', data)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(response.data, {'non_field_errors': ['Not a valid percent']})
+
 def _upload_death_star_plans(test_instance, login=True):
     if login:
         user = _fixture_user(test_instance)

--- a/tests/client/spec/services/validationsvc.js
+++ b/tests/client/spec/services/validationsvc.js
@@ -376,7 +376,7 @@ describe('Service: ValidationService', function () {
 
   it('should correctly validate that a valid percentage field is valid', function() {
     var elemData = {
-      'percentage_field1': '80'
+      'percentage_field1': '80.5'
     };
     var validationData = {};
     ValidationService.validate(percentageElements, elemData, validationData);
@@ -385,7 +385,7 @@ describe('Service: ValidationService', function () {
 
   it('should correctly validate an invalid percentage field greater than 100', function() {
     var elemData = {
-      'percentage_field1': '180'
+      'percentage_field1': '1800'
     };
     var validationData = {};
     ValidationService.validate(percentageElements, elemData, validationData);


### PR DESCRIPTION
A few of the percentage values requested by the application can be greater than 100%. This change alters the range to be 0-1000. For fields that should be less than 100, no_more_than validation logic should be used.