### PR TITLE
Adding a search bar to the empty proposals page.

### DIFF
--- a/sbirez/static/js/controllers/savedOpps.js
+++ b/sbirez/static/js/controllers/savedOpps.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('sbirezApp')
-  .controller('SavedOppsCtrl', function ($scope, $rootScope, SavedOpportunityService) {
+  .controller('SavedOppsCtrl', function ($scope, $rootScope, $state, SavedOpportunityService, SearchService) {
     $scope.data = {};
+    $scope.queryData = '';
     $rootScope.bodyClass = 'proposals';
 
     SavedOpportunityService.list().then(function(data){
@@ -13,4 +14,12 @@ angular.module('sbirezApp')
         $rootScope.bodyClass = 'proposals';
       }
     });
+
+    $scope.search = function() {
+      SearchService.search(1, $scope.queryData, 10).then(function(data) {
+        $state.go('app.search', {}, {'reload':true});
+      }, function(error) {
+        console.log(error);
+      });
+    };
   });

--- a/sbirez/static/sass/main.scss
+++ b/sbirez/static/sass/main.scss
@@ -1393,6 +1393,34 @@ body.proposals-no-results main div.wrap {
 body.proposals-no-results main div.wrap h1,
 body.topics-no-results main div.wrap h1{ margin-top: 0; }
 
+body.proposals-no-results main form {
+  position: relative;
+  padding-right: 96px;
+}
+
+body.proposals-no-results main form footer {
+  padding: 0;
+  margin: 0;
+  position: static;
+}
+
+body.proposals-no-results main p {
+  max-width: 50em; 
+}
+
+body.proposals-no-results main form div.field span.label-text {
+  position: absolute;
+  left: -9999em;
+}
+
+body.proposals-no-results main form .button {
+  width: 84px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 0;
+}
+
 /* @end */
 
 /* @group body.topics, body.proposals */

--- a/sbirez/static/views/partials/savedOpps.html
+++ b/sbirez/static/views/partials/savedOpps.html
@@ -1,7 +1,21 @@
 <main class="h-feed">
   <div class="wrap">
     <h1 class="p-name primary-header">My Proposals</h1>
-    <p ng-show="data.results.length === 0">You’ve yet to start a proposal! To get started, search for a topic and click "Start a proposal."</p>
+    <div ng-show="data.results.length === 0">
+      <p>You’ve not yet started a proposal.</p>
+      <p>To get started, search for a topic (like "aircraft", "software", or "electrochemical") and click "Start a proposal" on a result that interests you.</p>
+      <form ng-submit="search()">
+        <div class="field">
+          <label for="query">
+            <span class="label-text">Query</span>
+            <input type="search" id="query" name="query" ng-model="queryData"/>
+          </label>
+        </div>
+        <footer>
+          <input class="button" type="submit" value="Search">
+        </footer>
+      </form>
+    </div>
     <div ng-repeat="topic in data.results">
       <div topic="topic" view-details="true" save-option="true" create-option="true"></div>
     </div>

--- a/tests/client/spec/controllers/savedopps.js
+++ b/tests/client/spec/controllers/savedopps.js
@@ -83,13 +83,4 @@ describe('Controller: SavedOppsCtrl', function () {
     $httpBackend.flush();
   });
 
-  xit('clicking the remove button should remove a topic if logged in', function () {
-    AuthenticationService.setAuthenticated(true);
-    expect(scope.data).toEqual({});
-    $httpBackend.expectGET('api/v1/topics/?closed=true&saved=true').respond(data);
-    $httpBackend.expectGET('api/v1/proposals/').respond({});
-    $httpBackend.flush();
-    scope.removeOpportunity(1);
-    $httpBackend.expectDELETE('api/v1/topics/1/saved').respond(200);
-  });
 });


### PR DESCRIPTION
One of the pieces of feedback I got from the usability testing I did was that there was not enough information to get started on the empty proposals screen. This adds a more prominent search field and provides some sample search terms to get the user started.