### PR TITLE
Adds DAP reporting, tightens up GA settings

### DIFF
--- a/sbirez/templates/index.html
+++ b/sbirez/templates/index.html
@@ -46,7 +46,13 @@
        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      // anonymize user IPs (chops off the last IP triplet)
+      ga('set', 'anonymizeIp', true);
+    
+      // forces TLS even if the page were somehow loaded over http://
+      ga('set', 'forceSSL', true);
 
        ga('create', 'UA-49480678-2');
        ga('send', 'pageview');
@@ -71,5 +77,9 @@
       $httpProvider.defaults.headers.common['X-CSRFToken'] = '{{ csrf_token|escapejs }}';
     }]);
     </script>
+    
+    <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+    <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
+    
 </body>
 </html>


### PR DESCRIPTION
This adds a DAP embed code of:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

I specified a `GSA` value for the `agency` field, for lack of a better one.

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.

I also tightened up the app's GA settings to be in line with [18F's standard analytics settings](https://github.com/18F/analytics-standards#javascript-code-snippet).