### PR TITLE
Removing reliance on drf-jwt shim get_user_model.

### DIFF
--- a/sbirez/utils.py
+++ b/sbirez/utils.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 from rest_framework import exceptions
 from rest_framework.authentication import (BaseAuthentication,
                                            get_authorization_header)
-from rest_framework_jwt import utils
+from django.contrib.auth import get_user_model
 from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
 
@@ -49,7 +49,7 @@ class JSONWebTokenAuthenticationFlex(BaseJSONWebTokenAuthentication):
         """
         Returns an active user that matches the payload's user id and email.
         """
-        User = utils.get_user_model()
+        User = get_user_model()
 
         user_id = jwt_get_user_id_from_payload(payload)
         if user_id is not None:


### PR DESCRIPTION
authenticate_credentials in sbirez.utils was calling a drf-jwt wrapper for get_user_model. Since this was not being used elsewhere (and brings no inherit value to our project) it was replaced with the standard Django version.