### PR TITLE
Model change to remove 'null has no effect' warnings.

### DIFF
--- a/sbirez/migrations/0031_auto_20150828_1751.py
+++ b/sbirez/migrations/0031_auto_20150828_1751.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sbirez', '0030_auto_20150817_1927'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='area',
+            name='topics',
+            field=models.ManyToManyField(blank=True, to='sbirez.Topic', related_name='areas'),
+        ),
+        migrations.AlterField(
+            model_name='document',
+            name='proposals',
+            field=models.ManyToManyField(blank=True, to='sbirez.Proposal'),
+        ),
+        migrations.AlterField(
+            model_name='jargon',
+            name='elements',
+            field=models.ManyToManyField(blank=True, to='sbirez.Element', related_name='jargons'),
+        ),
+        migrations.AlterField(
+            model_name='keyword',
+            name='topics',
+            field=models.ManyToManyField(blank=True, to='sbirez.Topic', related_name='keywords'),
+        ),
+        migrations.AlterField(
+            model_name='naics',
+            name='firms',
+            field=models.ManyToManyField(blank=True, to='sbirez.Firm', related_name='naics'),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='saved_by',
+            field=models.ManyToManyField(blank=True, to=settings.AUTH_USER_MODEL, related_name='saved_topics'),
+        ),
+    ]

--- a/sbirez/models.py
+++ b/sbirez/models.py
@@ -53,7 +53,7 @@ class Firm(models.Model):
 class Naics(models.Model):
     code = models.TextField(primary_key=True)
     description = models.TextField(null=False)
-    firms = models.ManyToManyField('Firm', blank=True, null=True,
+    firms = models.ManyToManyField('Firm', blank=True, 
                                    related_name='naics')
 
     def __str__(self):
@@ -71,13 +71,13 @@ class PasswordHistory(models.Model):
 
 class Area(models.Model):
     area = models.TextField(unique=True)
-    topics = models.ManyToManyField('Topic', blank=True, null=True, related_name='areas')
+    topics = models.ManyToManyField('Topic', blank=True, related_name='areas')
 
 class Keyword(models.Model):
     keyword = models.CharField(max_length=255, unique=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    topics = models.ManyToManyField('Topic', blank=True, null=True, related_name='keywords')
+    topics = models.ManyToManyField('Topic', blank=True, related_name='keywords')
 
 class Phase(models.Model):
     phase = models.TextField()
@@ -365,7 +365,7 @@ class Element(models.Model):
 class Jargon(models.Model):
     name = models.TextField(unique=True)
     html = models.TextField()
-    elements = models.ManyToManyField('Element', blank=True, null=True,
+    elements = models.ManyToManyField('Element', blank=True,
                                       related_name='jargons')
 
 
@@ -407,7 +407,7 @@ class Topic(models.Model):
     objective = models.TextField()
     fts = VectorField()
     saved_by = models.ManyToManyField(settings.AUTH_USER_MODEL,
-                                      blank=True, null=True,
+                                      blank=True,
                                       related_name='saved_topics')
 
     objects = SearchManager(fields=None, search_field='fts',
@@ -432,7 +432,7 @@ class Document(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     firm = models.ForeignKey('Firm')
-    proposals = models.ManyToManyField('Proposal', blank=True, null=True,)
+    proposals = models.ManyToManyField('Proposal', blank=True)
 
     @property
     def file(self):


### PR DESCRIPTION
Running the database migrations generates a handful of warnings in the form: `(fields.W340) null has no effect on ManyToManyField`. This removes the null option for those fields.