### PR TITLE
Example of a PR if Snyk finds a hot patch fix for a vuln

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+ignore: {}
+patch:
+  'npm:uglify-js:20151024':
+    - 'bower@1.7.1 > handlebars@2.0.0 > uglify-js@2.3.6':
+        patched: '2015-12-12T18:50:27.349Z'
+version: v1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "sbirez",
   "version": "0.0.0",
   "dependencies": {
-    "bower": "^1.3.8"
+    "bower": "^1.3.8",
+    "snyk": "^1.6.1"
   },
   "devDependencies": {
     "karma": "~0.10.9",
@@ -10,5 +11,11 @@
     "karma-jasmine": "~0.1.5",
     "karma-ng-html2js-preprocessor": "*",
     "should": "~2.1.0"
-  }
+  },
+  "scripts": {
+    "test": "snyk test",
+    "snyk-protect": "snyk protect",
+    "postinstall": "npm run snyk-protect"
+  },
+  "snyk": true
 }


### PR DESCRIPTION
In the case of `uglify-js`, Snyk found a minor vuln. Uglify has a
direct patch, but the Bower dependency track is not using it yet. This
Snyk policy would ensure a hot patch of Uglify upon deploy.