### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,6 @@ buildpack: https://github.com/ddollar/heroku-buildpack-multi.git
 applications:
 - name: sbirez
   timeout: 180
-  command: export PATH=$PATH:/app/.heroku/src/pywkher/bin && waitress-serve --port=$VCAP_APP_PORT afsbirez.wsgi:application 
-  #command: python manage.py migrate --noinput && waitress-serve --port=$VCAP_APP_PORT afsbirez.wsgi:application 
+  command: export PATH=$PATH:/app/.heroku/src/pywkher/bin && waitress-serve --port=$PORT afsbirez.wsgi:application 
+  #command: python manage.py migrate --noinput && waitress-serve --port=$PORT afsbirez.wsgi:application 
   #command: export PATH=$PATH:/app/.heroku/src/pywkher/bin && python manage.py migrate && python manage.py readworkflow data/dod_workflow.yaml && python manage.py loaddata sbirez/fixtures/solicitation.json && python manage.py importtopics data/finaltopics.mdb "DoD SBIR 2015.1" && python manage.py getnaics && python manage.py indextopics && waitress-serve --port=$VCAP_APP_PORT afsbirez.wsgi:application 


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.